### PR TITLE
Remove babel object-spread plugin

### DIFF
--- a/addon/utils/computed-local-storage.js
+++ b/addon/utils/computed-local-storage.js
@@ -1,7 +1,7 @@
 import computed from 'ember-computed'
 
 const { localStorage, JSON } = window
-const { stringify, parse }   = JSON
+const { stringify, parse } = JSON
 
 const defaults = {
   storage: localStorage,
@@ -26,7 +26,7 @@ export default function computedStorage(storageKey, options) {
     deserialize,
     defaultValue,
     dependentKeys
-  } = { ...defaults, ...options }
+  } = Object.assign({}, defaults, options)
 
   return computed(...dependentKeys, {
     get() {
@@ -36,8 +36,7 @@ export default function computedStorage(storageKey, options) {
     set(key, val) {
       try {
         storage.setItem(storageKey, serialize(val))
-      }
-      catch (e) {
+      } catch (e) {
         console.error(e) //eslint-disable-line no-console
       }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,17 +1,17 @@
 /* eslint-env node */
-'use strict';
+'use strict'
 
-const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     babel: {
-      plugins: ['babel-plugin-transform-decorators-legacy', 'transform-object-rest-spread']
+      plugins: ['babel-plugin-transform-decorators-legacy']
     },
     'ember-cli-babel': {
       includePolyfill: true
-    },
-  });
+    }
+  })
 
   /*
     This build file specifies the options for the dummy test app of this
@@ -20,5 +20,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
-};
+  return app.toTree()
+}

--- a/index.js
+++ b/index.js
@@ -1,18 +1,12 @@
 /* eslint-env node */
-'use strict';
+'use strict'
 
 module.exports = {
   name: 'ember-sy',
-
-  options: {
-    babel: {
-      plugins: ['transform-object-rest-spread']
-    }
-  },
 
   included: function(app) {
     this._super.included(app)
 
     app.import('vendor/ember-sy/register-version.js')
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.5.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-adcssy": "github:adfinis-sygroup/ember-adcssy#v1.1.0",


### PR DESCRIPTION
This turned out to make the inclusion inside other apps more difficult.
Since we only used it at one place, let's just rewrite it and keep
things simple.